### PR TITLE
Add Token to Public Routes to Send back User Specific Data

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ import plansRouter from './routes/plans'
 import accountRouter from './routes/account'
 import swaggerUI from 'swagger-ui-express'
 import YAML from 'yamljs'
-import authMiddleware from './middlewares/authMiddleware'
+import authMiddleware, { optionalAuthMiddleware } from './middlewares/authMiddleware'
 import errorHandlerMiddleware from './middlewares/errorHandlerMiddleware'
 
 const app = express()
@@ -26,7 +26,7 @@ app.use(favicon(__dirname + '/public/favicon.ico'))
 
 // routes
 app.use('/api/v1', router)
-app.use('/api/v1/plans', plansRouter)
+app.use('/api/v1/plans', optionalAuthMiddleware, plansRouter)
 app.use('/api/v1/auth', authRouter)
 app.use('/api/v1/account', authMiddleware, accountRouter)
 

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -49,7 +49,7 @@ const fetchUserWithPlans = async (req: Request, res: Response) => {
 
   const user: IUser | null = await UserSchema.findById(userId)
     .orFail(new NotFoundError(`Item not found with the id: ${userId}`))
-    .select('-password')
+    .select('name imageURL')
     .lean()
 
   const filters = {

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -120,15 +120,20 @@ const fetchPlan = async (req: Request, res: Response) => {
   const stops = await StopSchema.find({ planId })
 
   const loggedInUser = req.user || null
+  let isBookmarked: boolean = false
+  if (loggedInUser) {
+    const res = await BookmarkSchema.exists({
+      userId: loggedInUser.userId,
+      planId,
+    }).lean()
+    if (res) {
+      isBookmarked = true
+    }
+  }
 
   res.status(StatusCodes.OK).json({
     ...plan,
-    isBookmarked: loggedInUser
-      ? await BookmarkSchema.exists({
-          userId: loggedInUser.userId,
-          planId,
-        }).lean()
-      : false,
+    isBookmarked,
     stops,
   })
 }

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -141,6 +141,11 @@ const fetchPlan = async (req: Request, res: Response) => {
   })
 }
 
+const fetchAllCategories = async (req: Request, res: Response) => {
+  const categories = await CategorySchema.find().lean()
+  res.status(StatusCodes.OK).json(categories)
+}
+
 const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
   if (!userId)
     return plans.map((plan) => ({
@@ -167,4 +172,4 @@ const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
   }))
 }
 
-export { fetchAllPlans, fetchPlan, fetchUserWithPlans, fetchCategoryWithPlans }
+export { fetchAllPlans, fetchPlan, fetchUserWithPlans, fetchCategoryWithPlans, fetchAllCategories }

--- a/src/controllers/plans.ts
+++ b/src/controllers/plans.ts
@@ -39,26 +39,6 @@ const fetchAllPlans = async (req: Request, res: Response) => {
   })
 }
 
-const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
-  // Extract only plan IDs
-  const planIds = plans.map((plan) => plan._id)
-
-  // Get plan IDs from bookmarks collection based on userId
-  const bookmarks = await BookmarkSchema.find({
-    userId,
-    planId: { $in: planIds },
-  }).select('planId')
-
-  // Create a Set for fast lookup
-  const bookmarkedPlanIds = new Set(bookmarks.map((b) => b.planId.toString()))
-
-  // Attach isBookmarked state to each plan
-  return plans.map((plan) => ({
-    ...plan,
-    isBookmarked: bookmarkedPlanIds.has(plan._id.toString()),
-  }))
-}
-
 const fetchUserWithPlans = async (req: Request, res: Response) => {
   const { userId } = req.params
   const { page = 1, size = PAGE_SIZE } = req.query
@@ -137,6 +117,26 @@ const fetchPlan = async (req: Request, res: Response) => {
     ...plan,
     stops,
   })
+}
+
+const attachBookmarkFlagToPlans = async (plans: IPlan[], userId: string) => {
+  // Extract only plan IDs
+  const planIds = plans.map((plan) => plan._id)
+
+  // Get plan IDs from bookmarks collection based on userId
+  const bookmarks = await BookmarkSchema.find({
+    userId,
+    planId: { $in: planIds },
+  }).select('planId')
+
+  // Create a Set for fast lookup
+  const bookmarkedPlanIds = new Set(bookmarks.map((b) => b.planId.toString()))
+
+  // Attach isBookmarked state to each plan
+  return plans.map((plan) => ({
+    ...plan,
+    isBookmarked: bookmarkedPlanIds.has(plan._id.toString()),
+  }))
 }
 
 export { fetchAllPlans, fetchPlan, fetchUserWithPlans, fetchCategoryWithPlans }

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -25,7 +25,7 @@ const authMiddleware = async (request: Request, response: Response, next: NextFu
     // Attach the user to the authorized route
     const user: IUser = await UserSchema.findById(payload.userId)
       .orFail(new UnauthenticatedError('User not found, please login again'))
-      .select('-password')
+      .select('name imageURL email')
     request.user = { userId: user._id, name: user.name, email: user.email, token }
     next()
   } catch {
@@ -43,7 +43,7 @@ export const optionalAuthMiddleware = async (request: Request, response: Respons
       console.log('payload', payload)
 
       // Attach the user to the authorized route
-      const user: IUser = await UserSchema.findById(payload.userId).select('-password')
+      const user: IUser = await UserSchema.findById(payload.userId).select('name imageURL email')
       if (user) {
         request.user = { userId: user._id, name: user.name, email: user.email, token }
       }

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -33,4 +33,25 @@ const authMiddleware = async (request: Request, response: Response, next: NextFu
   }
 }
 
+export const optionalAuthMiddleware = async (request: Request, response: Response, next: NextFunction) => {
+  const authHeader = request.headers.authorization
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.split(' ')[1]
+
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET_KEY as string) as MyJwtPayload
+      console.log('payload', payload)
+
+      // Attach the user to the authorized route
+      const user: IUser = await UserSchema.findById(payload.userId).select('-password')
+      if (user) {
+        request.user = { userId: user._id, name: user.name, email: user.email, token }
+      }
+    } catch {
+      // do nothing
+    }
+  }
+  next()
+}
+
 export default authMiddleware

--- a/src/routes/plans.ts
+++ b/src/routes/plans.ts
@@ -1,10 +1,17 @@
 import express from 'express'
-import { fetchAllPlans, fetchPlan, fetchUserWithPlans, fetchCategoryWithPlans } from '../controllers/plans'
+import {
+  fetchAllPlans,
+  fetchPlan,
+  fetchUserWithPlans,
+  fetchCategoryWithPlans,
+  fetchAllCategories,
+} from '../controllers/plans'
 
 const router = express.Router()
 
 router.route('/').get(fetchAllPlans)
 // Specific routes first
+router.route('/category').get(fetchAllCategories)
 router.route('/user/:userId').get(fetchUserWithPlans)
 router.route('/category/:categoryId').get(fetchCategoryWithPlans)
 // Generic route last to avoid conflicts

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -186,6 +186,40 @@ paths:
                 }
           headers: {}
       deprecated: false
+  /plans/category:
+    get:
+      tags:
+        - Plans
+      summary: Get list of all categories
+      parameters: []
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              example: |
+                [
+                  {
+                    "_id": "680819f66e7cdbc049ab3f57",
+                    "name": "City Exploration",
+                    "description": "Explore the city's landmarks, parks, museums, and dining spots.",
+                    "imageURL": "https://example.com/city-exploration.jpg"
+                  },
+                  {
+                    "_id": "68081b006e7cdbc049ab3f58",
+                    "name": "Urban Adventure",
+                    "description": "Discover the vibrant city life, parks, museums, and culinary delights.",
+                    "imageURL": "https://example.com/urban-adventure.jpg"
+                  },
+                  {
+                    "_id": "68081b546e7cdbc049ab3f59",
+                    "name": "Food and Drink Gems",
+                    "description": "Restaurants, Bars and Cafes",
+                    "imageURL": "https://example.com/food-and-drink-gems.jpg"
+                  }
+                ]
+          headers: {}
+      deprecated: false
   /plans/category/{categoryId}:
     parameters:
       - in: path

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -56,6 +56,7 @@ paths:
                         "_id": "67fdfe49d9c143f362fb9702",
                         "name": "My first cat"
                       },
+                      "isBookmarked": false,
                       "createdAt": "2025-04-04T16:50:54Z",
                       "updatedAt": "2025-04-04T16:50:54Z"
                     }
@@ -105,6 +106,7 @@ paths:
                     "_id": "67fdfe49d9c143f362fb9702",
                     "name": "My first cat"
                   },
+                  "isBookmarked": false,
                   "createdAt": "2025-04-04T16:50:54Z",
                   "updatedAt": "2025-04-04T16:50:54Z",
                   "stops": [
@@ -175,6 +177,7 @@ paths:
                           "_id": "67fdfe49d9c143f362fb9702",
                           "name": "My first cat"
                         },
+                        "isBookmarked": false,
                         "createdAt": "2025-04-04T17:00:54Z",
                         "updatedAt": "2025-04-04T17:00:54Z"
                       }
@@ -234,6 +237,7 @@ paths:
                           "_id": "67fdfe49d9c143f362fb9702",
                           "name": "My first cat"
                         },
+                        "isBookmarked": false,
                         "createdAt": "2025-04-04T17:00:54Z",
                         "updatedAt": "2025-04-04T17:00:54Z"
                       }


### PR DESCRIPTION
## Description

1. Implemented an optional `authMiddleware` and applied it to the `plans` public endpoints. This allows the `/plans` endpoints to handle requests with or without a Bearer token. If a token is provided, the response includes each plan's bookmark status; if not, it returns the standard plan data as before.
2. Updated the swagger with the updated details.

## Related Issue

Previously, I handled displaying bookmarked plans on frontend > homepage using two API calls: first fetch all plans, and then another one to fetch the IDs of the user's bookmarked plans. I know, it was a dump approach, but I thought it would be a quick solution. Eventually, I ended up modifying the `api/v1/plans` API to accept a optional Bearer token and return plans along with their bookmark status. That change made things much simpler on the frontend.

## Acceptance Criteria

All the following endpoints should work normally as before, the only change is on returned json on response, now each plan have `isBookmarked` with false value, and if bearer token provided then the value of `isBookmarked` changed based on user's data. Here are the affected endpoints:
- /api/v1/plans
- /api/v1/plans/{planId}
- /api/v1/plans/category/{categoryId}
- /api/v1/plans/user/{userId}

## Testing Instructions

- Switch branch on your frontend clone to `plans-public-routes` from [PR #43](https://github.com/Code-the-Dream-School/ii-practicum-team-5-front/pull/43).
- Run frontend server, open homepage, login and try to bookmark few plans in homepage or in search result page.
- Logout and login again, bookmarked plans should stay the same with a yellow bookmark icon.